### PR TITLE
몬스터 쉐이더 변경 및 플레이어 시야 수정

### DIFF
--- a/Assets/Enemy/Boon_yeol_che.prefab
+++ b/Assets/Enemy/Boon_yeol_che.prefab
@@ -325,7 +325,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: f14e6b95b7c6e654dbf966be49cc373b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Enemy/Boon_yeol_gwi.prefab
+++ b/Assets/Enemy/Boon_yeol_gwi.prefab
@@ -53,7 +53,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: f14e6b95b7c6e654dbf966be49cc373b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -274,7 +274,6 @@ MonoBehaviour:
   sp: {fileID: 1870475998552291777}
   anim: {fileID: 0}
   enemyCorpse: {fileID: 8557445870057906743, guid: d9bfa187f8d7f25489bc60875b28c9ac, type: 3}
-  enemy_Corpse_data: {fileID: 11400000, guid: 160f2d3033bb9524fa884c730fd94f73, type: 2}
   enemySelf: {fileID: 3039830139207019956}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0

--- a/Assets/Enemy/Eo_Dook_Jwi.prefab
+++ b/Assets/Enemy/Eo_Dook_Jwi.prefab
@@ -268,7 +268,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: f14e6b95b7c6e654dbf966be49cc373b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Enemy/LandShark.prefab
+++ b/Assets/Enemy/LandShark.prefab
@@ -53,7 +53,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: f14e6b95b7c6e654dbf966be49cc373b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Enemy/Mumyeon_Gwi.prefab
+++ b/Assets/Enemy/Mumyeon_Gwi.prefab
@@ -239,7 +239,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: f14e6b95b7c6e654dbf966be49cc373b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Enemy/PlayerSight.cs
+++ b/Assets/Enemy/PlayerSight.cs
@@ -13,11 +13,13 @@ public class PlayerSight : MonoBehaviour
         TurnSight();
     }
 
+    // 마우스 방향으로 보고 있음. 방향이 맞지 않으면 추후 의논
     void TurnSight()
     {
         mousePosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
-        aimDir = (transform.position - mousePosition).normalized;
+        mousePosition.z = 0f; // z축 고정
+        aimDir = (mousePosition - transform.position).normalized;
         angle = Mathf.Atan2(aimDir.y, aimDir.x) * Mathf.Rad2Deg;
-        transform.rotation = Quaternion.Euler(0f, 0f, angle);
+        transform.rotation = Quaternion.Euler(0f, 0f, angle - 90f); // ← 여기에 -90도 보정
     }
 }

--- a/Assets/Enemy/Script/Eo-dook-jwi/Eo_dook_jwi.cs
+++ b/Assets/Enemy/Script/Eo-dook-jwi/Eo_dook_jwi.cs
@@ -64,16 +64,33 @@ public class Eo_dook_jwi : Enemy
 
     public override void EnemyMove()
     {
-        //빛에 닿았을 시
-        if(isLighting)
-        {
-            enemyMoveDir = -(player.transform.position - transform.position).normalized;
+        // 빛에 닿으면 도망가는 기믹은 일단 제거해줌
+        ////빛에 닿았을 시
+        //if(isLighting)
+        //{
+        //    enemyMoveDir = -(player.transform.position - transform.position).normalized;
 
-            transform.Translate(enemyMoveDir * enemyRunSpeed * Time.deltaTime);
-        }
+        //    transform.Translate(enemyMoveDir * enemyRunSpeed * Time.deltaTime);
+        //}
+
+        ////추적중이 아니면
+        //else if (!isTrace && !isDie && !isEnemyHit)
+        //{
+        //    //스프라이트 때문에 이걸 사용해줌
+        //    //EnemyNormalTurn2();
+
+        //    //에니메이션, 추적 false로 바꾸어줌
+        //    //anim.SetBool("isTrace", false);
+
+        //    // 현재 방향으로 이동
+        //    transform.Translate(moveDirection * enemyMoveSpeed * Time.deltaTime);
+
+        //    // 시간을 더해줌
+        //    moveTime += Time.deltaTime;
+        //}
 
         //추적중이 아니면
-        else if (!isTrace && !isDie && !isEnemyHit)
+        if (!isTrace && !isDie && !isEnemyHit)
         {
             //스프라이트 때문에 이걸 사용해줌
             //EnemyNormalTurn2();

--- a/Assets/Enemy/Somyeon_Gwi.prefab
+++ b/Assets/Enemy/Somyeon_Gwi.prefab
@@ -87,7 +87,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: f14e6b95b7c6e654dbf966be49cc373b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -227,6 +227,8 @@ MonoBehaviour:
   landShark: {fileID: 0}
   landSharkAttack: {fileID: 0}
   somyeon_Gwi: {fileID: 7782386398963764363}
+  boon_yeol_gwi: {fileID: 0}
+  mumyeon_Gwi: {fileID: 0}
   landSharkAttackTime: 0
 --- !u!1 &7361896408967136244
 GameObject:
@@ -364,7 +366,6 @@ MonoBehaviour:
   sp: {fileID: 0}
   anim: {fileID: 0}
   enemyCorpse: {fileID: 8557445870057906743, guid: d9bfa187f8d7f25489bc60875b28c9ac, type: 3}
-  enemy_Corpse_data: {fileID: 11400000, guid: 160f2d3033bb9524fa884c730fd94f73, type: 2}
   enemySelf: {fileID: 2403785873192651292}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0

--- a/Assets/Prefab/Enemy/StealEnemy.prefab
+++ b/Assets/Prefab/Enemy/StealEnemy.prefab
@@ -53,7 +53,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: f14e6b95b7c6e654dbf966be49cc373b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Prefab/Enemy/WomanGhost.prefab
+++ b/Assets/Prefab/Enemy/WomanGhost.prefab
@@ -53,7 +53,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: f14e6b95b7c6e654dbf966be49cc373b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Prefab/Enemy/Yang.prefab
+++ b/Assets/Prefab/Enemy/Yang.prefab
@@ -359,7 +359,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: f14e6b95b7c6e654dbf966be49cc373b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Prefab/Enemy/Yin.prefab
+++ b/Assets/Prefab/Enemy/Yin.prefab
@@ -235,7 +235,7 @@ SpriteRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 2100000, guid: f14e6b95b7c6e654dbf966be49cc373b, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/Assets/Prefab/Player.prefab
+++ b/Assets/Prefab/Player.prefab
@@ -460,7 +460,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 3756239094711212613}
-  - {fileID: 4690670508619841021}
+  - {fileID: 4712927130067077083}
   - {fileID: 3477878252754912574}
   - {fileID: 7980305839262368599}
   m_Father: {fileID: 0}
@@ -623,6 +623,7 @@ MonoBehaviour:
   spSpendThreshold: 0.1
   spSpendAmount: 1
   currentState: 0
+  isMoving: 0
   corpse: {fileID: 8291217679533633708, guid: 20be9ea67cd251e4d8479e6738e65c7e, type: 3}
 --- !u!114 &6102694892513399258
 MonoBehaviour:
@@ -636,11 +637,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6e14adfdf9b1c0c4fb1052779910d3a7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  quickSlots:
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
-  - {fileID: 0}
   selectedSlotIndex: 0
   dropPoint: {fileID: 8194112692264653263}
   itemLayer:
@@ -718,7 +714,7 @@ MonoBehaviour:
   - {x: -0.05387208, y: -0.22353303, z: 0}
   m_ShapePathHash: -1562121249
   m_Mesh: {fileID: 0}
-  m_InstanceId: -13898
+  m_InstanceId: 62182
   m_LocalBounds:
     m_Center: {x: 0.0002822429, y: -0.064456046, z: 0}
     m_Extent: {x: 0.114839226, y: 0.39820114, z: 0}
@@ -886,6 +882,38 @@ CircleCollider2D:
   m_Offset: {x: 0, y: 0}
   serializedVersion: 2
   m_Radius: 4.5
+--- !u!1 &5778879907946963948
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4712927130067077083}
+  m_Layer: 0
+  m_Name: Sight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4712927130067077083
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5778879907946963948}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4690670508619841021}
+  m_Father: {fileID: 8194112692264653263}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7431442948585479728
 GameObject:
   m_ObjectHideFlags: 0
@@ -1143,7 +1171,8 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4690670508619841021}
-  - component: {fileID: 4609479539692996639}
+  - component: {fileID: 7647500816381502098}
+  - component: {fileID: 1658551752753831148}
   m_Layer: 0
   m_Name: Sight
   m_TagString: Sight
@@ -1159,15 +1188,15 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8594319365050642194}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 8194112692264653263}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!58 &4609479539692996639
-CircleCollider2D:
+  m_Father: {fileID: 4712927130067077083}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
+--- !u!60 &7647500816381502098
+PolygonCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -1199,5 +1228,33 @@ CircleCollider2D:
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.1
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: 0.66571784, y: 3.7727888}
+      - {x: -0.49980456, y: 3.7500162}
+      - {x: -1.5401988, y: 3.3275077}
+      - {x: -0.2252681, y: -0.02208972}
+      - {x: 0.17221698, y: -0.030931473}
+      - {x: 1.5503919, y: 3.2917109}
+  m_UseDelaunayMesh: 0
+--- !u!114 &1658551752753831148
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8594319365050642194}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d755477936bc24848a6fcf3c5e7911f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scenes/InGame_Scenes.unity
+++ b/Assets/Scenes/InGame_Scenes.unity
@@ -201,14 +201,26 @@ PrefabInstance:
     - target: {fileID: 4440181562815899954, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 1595095250}
+      objectReference: {fileID: 1103174443}
     - target: {fileID: 4440181562815899954, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
       propertyPath: m_InstanceId
-      value: -1502
+      value: -379640
       objectReference: {fileID: 0}
     - target: {fileID: 4570968210770061853, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
       propertyPath: searchRadius
       value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 4712927130067077083, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4712927130067077083, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4712927130067077083, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5401896716427406278, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
       propertyPath: m_Name
@@ -258,11 +270,96 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    m_RemovedComponents: []
+    m_RemovedComponents:
+    - {fileID: 4609479539692996639, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
+    - {fileID: 7647500816381502098, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
+    - {fileID: 1658551752753831148, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
     m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 8194112692264653263, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
+      insertIndex: 1
+      addedObject: {fileID: 2110110744}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8594319365050642194, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 431154211}
+    - targetCorrespondingSourceObject: {fileID: 8594319365050642194, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 431154212}
   m_SourcePrefab: {fileID: 100100000, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
+--- !u!1 &431154210 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8594319365050642194, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
+  m_PrefabInstance: {fileID: 431154209}
+  m_PrefabAsset: {fileID: 0}
+--- !u!60 &431154211
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 431154210}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: 0.36966574, y: 2.0667248}
+      - {x: -0.19603693, y: 2.0659513}
+      - {x: -0.75501955, y: 1.6935282}
+      - {x: -0.26922506, y: -0.14739215}
+      - {x: 0.18345904, y: -0.14739221}
+      - {x: 0.9142996, y: 1.6200144}
+  m_UseDelaunayMesh: 0
+--- !u!114 &431154212
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 431154210}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d755477936bc24848a6fcf3c5e7911f9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &653120295 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 8194112692264653263, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
+  m_PrefabInstance: {fileID: 431154209}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1088370148
 GameObject:
   m_ObjectHideFlags: 0
@@ -345,7 +442,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &1595095250
+--- !u!43 &1103174443
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -567,6 +664,37 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d958a2ab5a163de448ef93dfb29f51ab, type: 3}
+--- !u!1 &2110110743
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2110110744}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2110110744
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2110110743}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 653120295}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &50871118671845587
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
기존 몬스터들은 어두워도 보였기에 머테리얼을 수정하여 어두워도 안보이게 해주었음
단 사신은 제외하였음
또한 플레이어의 Sight를 수정해주었는데 마우스의 방향에 따라 회전하도록 해주었음.