### PR TITLE
적 충돌 방식 변경

### DIFF
--- a/Assets/Enemy/Boon_yeol_che.prefab
+++ b/Assets/Enemy/Boon_yeol_che.prefab
@@ -137,6 +137,7 @@ MonoBehaviour:
   anim: {fileID: 0}
   enemyCorpse: {fileID: 8557445870057906743, guid: d9bfa187f8d7f25489bc60875b28c9ac, type: 3}
   enemySelf: {fileID: 7133274805120073796}
+  enemyColl: {fileID: 7221030420655169584}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0
   rigid: {fileID: 0}

--- a/Assets/Enemy/Boon_yeol_gwi.prefab
+++ b/Assets/Enemy/Boon_yeol_gwi.prefab
@@ -275,6 +275,7 @@ MonoBehaviour:
   anim: {fileID: 0}
   enemyCorpse: {fileID: 8557445870057906743, guid: d9bfa187f8d7f25489bc60875b28c9ac, type: 3}
   enemySelf: {fileID: 3039830139207019956}
+  enemyColl: {fileID: 5705392239228176384}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0
   rigid: {fileID: 0}

--- a/Assets/Enemy/Eo_Dook_Jwi.prefab
+++ b/Assets/Enemy/Eo_Dook_Jwi.prefab
@@ -138,6 +138,7 @@ MonoBehaviour:
   anim: {fileID: 0}
   enemyCorpse: {fileID: 8557445870057906743, guid: d9bfa187f8d7f25489bc60875b28c9ac, type: 3}
   enemySelf: {fileID: 4761938672998679258}
+  enemyColl: {fileID: 534602614189433843}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0
   rigid: {fileID: 0}

--- a/Assets/Enemy/LandShark.prefab
+++ b/Assets/Enemy/LandShark.prefab
@@ -414,6 +414,7 @@ MonoBehaviour:
   anim: {fileID: 0}
   enemyCorpse: {fileID: 8557445870057906743, guid: d9bfa187f8d7f25489bc60875b28c9ac, type: 3}
   enemySelf: {fileID: 6855693868523006174}
+  enemyColl: {fileID: 3654836320264230940}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0
   rigid: {fileID: 0}

--- a/Assets/Enemy/Mumyeon_Gwi.prefab
+++ b/Assets/Enemy/Mumyeon_Gwi.prefab
@@ -181,6 +181,7 @@ MonoBehaviour:
   anim: {fileID: 0}
   enemyCorpse: {fileID: 0}
   enemySelf: {fileID: 1986939775975959373}
+  enemyColl: {fileID: 3608480653872384500}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0
   rigid: {fileID: 0}

--- a/Assets/Enemy/Script/Eo-dook-jwi/Eo_dook_jwi.cs
+++ b/Assets/Enemy/Script/Eo-dook-jwi/Eo_dook_jwi.cs
@@ -136,10 +136,32 @@ public class Eo_dook_jwi : Enemy
                 //∫˚ø° ¥Í¿∏∏È true∑Œ «ÿ¡÷∞Ì µµ∏¡∞°∞‘ «ÿ¡‹
                 isLighting = true;
             }
-
-
         }
     }
+
+
+    void OnCollisionExit2D(Collision2D collision)
+    {
+        if (collision != null)
+        {
+            if (collision.gameObject.CompareTag("Wall"))
+            {
+                WallCollOrigin();
+            }
+        }
+    }
+
+    void OnTriggerStay2D(Collider2D collision)
+    {
+        if (collision != null)
+        {
+            if (collision.gameObject.CompareTag("Wall"))
+            {
+                WallNotCross();
+            }
+        }
+    }
+
 
     void OnTriggerExit2D(Collider2D collision)
     {

--- a/Assets/Enemy/Script/LandShark/LandShark.cs
+++ b/Assets/Enemy/Script/LandShark/LandShark.cs
@@ -166,5 +166,40 @@ public class LandShark : Enemy
 
         yield return null;
     }
+    void OnCollisionExit2D(Collision2D collision)
+    {
+        if (collision != null)
+        {
+            if (collision.gameObject.CompareTag("Wall"))
+            {
+                WallCollOrigin();
+            }
+        }
+    }
+
+    void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision != null)
+        {
+            if (collision.gameObject.CompareTag("Wall"))
+            {
+                WallNotCross();
+            }
+        }
+    }
+
+    void OnTriggerStay2D(Collider2D collision)
+    {
+        if (collision != null)
+        {
+
+            if (collision.gameObject.CompareTag("Wall"))
+            {
+                WallNotCross();
+            }
+        }
+    }
+
+
 
 }

--- a/Assets/Enemy/Somyeon_Gwi.prefab
+++ b/Assets/Enemy/Somyeon_Gwi.prefab
@@ -367,6 +367,7 @@ MonoBehaviour:
   anim: {fileID: 0}
   enemyCorpse: {fileID: 8557445870057906743, guid: d9bfa187f8d7f25489bc60875b28c9ac, type: 3}
   enemySelf: {fileID: 2403785873192651292}
+  enemyColl: {fileID: 7465418123219731909}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0
   rigid: {fileID: 0}

--- a/Assets/Prefab/Enemy/StealEnemy.prefab
+++ b/Assets/Prefab/Enemy/StealEnemy.prefab
@@ -253,6 +253,7 @@ MonoBehaviour:
   anim: {fileID: 0}
   enemyCorpse: {fileID: 8557445870057906743, guid: d9bfa187f8d7f25489bc60875b28c9ac, type: 3}
   enemySelf: {fileID: 5341648827927804214}
+  enemyColl: {fileID: 3569553528630324326}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0
   rigid: {fileID: 0}

--- a/Assets/Prefab/Enemy/WomanGhost.prefab
+++ b/Assets/Prefab/Enemy/WomanGhost.prefab
@@ -271,6 +271,7 @@ MonoBehaviour:
   anim: {fileID: 636676555407985214}
   enemyCorpse: {fileID: 8557445870057906743, guid: d9bfa187f8d7f25489bc60875b28c9ac, type: 3}
   enemySelf: {fileID: 4938018955128738630}
+  enemyColl: {fileID: 6802393282543350068}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0
   rigid: {fileID: 0}

--- a/Assets/Prefab/Enemy/Yang.prefab
+++ b/Assets/Prefab/Enemy/Yang.prefab
@@ -171,6 +171,7 @@ MonoBehaviour:
   anim: {fileID: 0}
   enemyCorpse: {fileID: 8557445870057906743, guid: d9bfa187f8d7f25489bc60875b28c9ac, type: 3}
   enemySelf: {fileID: 85314243712649985}
+  enemyColl: {fileID: 1360868529527927972}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0
   rigid: {fileID: 0}

--- a/Assets/Prefab/Enemy/Yin.prefab
+++ b/Assets/Prefab/Enemy/Yin.prefab
@@ -138,6 +138,7 @@ MonoBehaviour:
   anim: {fileID: 0}
   enemyCorpse: {fileID: 8557445870057906743, guid: d9bfa187f8d7f25489bc60875b28c9ac, type: 3}
   enemySelf: {fileID: 958911829622340847}
+  enemyColl: {fileID: 8828818602060007957}
   enemyTargetDir: {x: 0, y: 0, z: 0}
   isDie: 0
   rigid: {fileID: 0}

--- a/Assets/Script/Enemy/Enemy.cs
+++ b/Assets/Script/Enemy/Enemy.cs
@@ -76,6 +76,7 @@ public abstract class Enemy     : MonoBehaviour
     public Animator             anim;
     public GameObject           enemyCorpse; //적 시체
     public GameObject           enemySelf;
+    public Collider2D           enemyColl;
 
     [HideInInspector] public Vector3       enemyTargetDir; //적의 타겟 방향
 
@@ -279,6 +280,22 @@ public abstract class Enemy     : MonoBehaviour
         if (enemyTargetDir.x < 0) { sp.flipX = false; }
         else if (enemyTargetDir.x > 0) { sp.flipX = true; }
     }
+    #endregion
+
+    #region 벽 충돌 처리
+
+    //  벽을 못넘게 해주는 메서드
+    public void WallNotCross()
+    {
+        enemyColl.isTrigger = false;
+    }
+
+    // 다시 원래대로 해주는 메서드
+    public void WallCollOrigin()
+    {
+        enemyColl.isTrigger = true;
+    }
+
     #endregion
 
 


### PR DESCRIPTION
적에게 자기 자신의 콜라이더를 참조해
벽의 태그를 비교해 요괴면 벽을 못넘게 수정해주었음
이제 유령은 벽을 자유롭게 통과하고
요괴는 벽에 충돌될시 isTrigger를 활성화 했다 비활성화 하는 방식으로 충돌이 되게 해주었음