### PR TITLE
처녀귀신 수정 및 시체 처리 임시 제작

### DIFF
--- a/Assets/Enemy/Script/Boon-yeol-gwi/Boon_yeol_gwi.cs
+++ b/Assets/Enemy/Script/Boon-yeol-gwi/Boon_yeol_gwi.cs
@@ -141,7 +141,6 @@ public class Boon_yeol_gwi : Enemy
         {
             //피격 효과
             Attack_sc attack = collision.GetComponent<Attack_sc>();
-            Debug.Log("분열귀 피격 중");
             if (collision.gameObject.CompareTag("Attack") && !isEnemyHit && attack != null)
             {
                 Debug.Log("분열귀 피격");

--- a/Assets/Enemy/TestCorpse.prefab
+++ b/Assets/Enemy/TestCorpse.prefab
@@ -1,0 +1,86 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7154245528468498525
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3400915481631615318}
+  - component: {fileID: 4415803407673412217}
+  m_Layer: 0
+  m_Name: TestCorpse
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3400915481631615318
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7154245528468498525}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &4415803407673412217
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7154245528468498525}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 7aa4b1c0c62fbd84aa333af1d89239b6, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 0.96, y: 0.96}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/Enemy/TestCorpse.prefab.meta
+++ b/Assets/Enemy/TestCorpse.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2900bd9a0b93c7a4fa645e2b0e2d1bd0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Enemy/WomanGhostKey.cs
+++ b/Assets/Enemy/WomanGhostKey.cs
@@ -6,6 +6,10 @@ public class WomanGhostKey : MonoBehaviour
 {
     public GameObject womanGhostKeyCanvas;
     public bool isActive;
+    public GameObject leftKey;
+    public GameObject rightKey;
+    Coroutine keyCoroutine;
+
 
     public void Update()
     {
@@ -13,11 +17,42 @@ public class WomanGhostKey : MonoBehaviour
         if(isActive)
         {
             womanGhostKeyCanvas.SetActive(true);
+
+            if (keyCoroutine == null)
+            {
+                keyCoroutine = StartCoroutine(KeyShow());
+            }
         }
-        // 비활성화 되어있으면 꺼줌
         else if (!isActive)
         {
+            // 비활성화 시 코루틴 멈춤
+            if (keyCoroutine != null)
+            {
+                StopCoroutine(keyCoroutine);
+                keyCoroutine = null;
+            }
+
             womanGhostKeyCanvas.SetActive(false);
+        }
+    }
+
+
+    IEnumerator KeyShow()
+    {
+        while (isActive)
+        {
+            if (leftKey.activeSelf)
+            {
+                rightKey.SetActive(true);
+                leftKey.SetActive(false);
+            }
+            else if (rightKey.activeSelf)
+            {
+                leftKey.SetActive(true);
+                rightKey.SetActive(false);
+            }
+
+            yield return new WaitForSeconds(0.33f);
         }
     }
 }

--- a/Assets/Prefab/Player.prefab
+++ b/Assets/Prefab/Player.prefab
@@ -821,7 +821,7 @@ MonoBehaviour:
   - {x: -0.05387208, y: -0.22353303, z: 0}
   m_ShapePathHash: -1562121249
   m_Mesh: {fileID: 0}
-  m_InstanceId: 56540
+  m_InstanceId: 36938
   m_LocalBounds:
     m_Center: {x: 0.0002822429, y: -0.064456046, z: 0}
     m_Extent: {x: 0.114839226, y: 0.39820114, z: 0}
@@ -885,6 +885,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   womanGhostKeyCanvas: {fileID: 456099418970359733}
   isActive: 0
+  leftKey: {fileID: 7849976470518531551}
+  rightKey: {fileID: 8307003349619021305}
 --- !u!1 &5451118422819145829
 GameObject:
   m_ObjectHideFlags: 0
@@ -1293,7 +1295,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &8873486493140312114
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/InGame_Scenes.unity
+++ b/Assets/Scenes/InGame_Scenes.unity
@@ -212,10 +212,10 @@ PrefabInstance:
     - target: {fileID: 4440181562815899954, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
       propertyPath: m_Mesh
       value: 
-      objectReference: {fileID: 1249211648}
+      objectReference: {fileID: 1498990541}
     - target: {fileID: 4440181562815899954, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
       propertyPath: m_InstanceId
-      value: -4042
+      value: -3214
       objectReference: {fileID: 0}
     - target: {fileID: 4440181562815899954, guid: 68ca3f8e0ec26cd43a7e08cc91bf580a, type: 3}
       propertyPath: m_ApplyToSortingLayers.Array.size
@@ -463,7 +463,7 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &1249211648
+--- !u!43 &1498990541
 Mesh:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}

--- a/Assets/Script/Enemy/Enemy.cs
+++ b/Assets/Script/Enemy/Enemy.cs
@@ -267,8 +267,8 @@ public abstract class Enemy     : MonoBehaviour
             yield return new WaitForSeconds(0.01f);
         }
 
-        Destroy(transform.parent.gameObject);
-        //EnemyCorpseSummon();
+        //Destroy(transform.parent.gameObject);
+        EnemyCorpseSummon();
     }
 
     //적이 죽을떄 시체를 소환하는 메서드
@@ -277,11 +277,11 @@ public abstract class Enemy     : MonoBehaviour
         //생성한 적 시체 게임오브젝트를 가져와 저장해줌
         GameObject corpse = Instantiate(this.enemyCorpse, transform.position, transform.rotation);
         //그 후 EnemyCorpse 컴포넌트를 가져와줌
-        EnemyCorpse enemyCorpse = corpse.GetComponent<EnemyCorpse>();
+        //EnemyCorpse enemyCorpse = corpse.GetComponent<EnemyCorpse>();
         //이름 정보와 가격을 전달해줌
-        enemyCorpse.corpseName = $"{enemyName}의 영혼";
-        enemyCorpse.corpseGold = enemyPrice;
-        enemyCorpse.corpseHeight = enemyHeight;
+        //enemyCorpse.corpseName = $"{enemyName}의 영혼";
+        //enemyCorpse.corpseGold = enemyPrice;
+        //enemyCorpse.corpseHeight = enemyHeight;
 
         //마지막으로 자기 자신을 지워줌
         //부모 오브젝트도 통으로 지워줌


### PR DESCRIPTION
처녀귀신 빙의시 너무 밋밋한 것 같기에 키보드를 0.33초마다 좌 우 번갈아가며 활성화 시켜주었음 또한 몬스터가 죽으면 시체가 나오도록 임시로 제작하엿으며, 추후 시체를 어떤 방식으로 하냐에 따라 수정할 예정